### PR TITLE
docs: add first-class crate-level documentation to all crates

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -120,3 +120,17 @@ Mandatory metrics updates for durability/recovery changes:
 - **Design patterns:** Solve problems using well-known engineering design patterns. Choose the pattern that fits the problem — don't force-fit, but don't ad-hoc either. Name and document the pattern in use.
 - **Mandatory refactor pass:** No work is considered complete until a final refactoring pass has been done for code quality — naming, structure, duplication, and adherence to SOLID.
 - **Mandatory gap review:** No work is considered complete until a review for gaps has been performed — missing edge cases, untested paths, incomplete error handling, and architectural blind spots.
+
+## Documentation Standards
+
+- **First-class open source quality required.** Follow the standard set by top Rust crates (tokio, serde, crossbeam, rocksdb). Documentation that merely restates what the code does is not acceptable.
+- **Crate-level `//!` docs are mandatory** in every `lib.rs`. These are the landing pages in `cargo doc`. They must include:
+  - A one-sentence summary (appears in workspace index).
+  - What problem this crate solves within TardigradeDB's 4-layer architecture.
+  - An ASCII text diagram where the crate's architecture benefits from visualization.
+  - Key public types/functions linked with `[Type]` intra-doc links.
+  - At least one working `# Usage` code example for the most important public API.
+  - Cross-references to related crates.
+- **Module-level `//!` docs** must explain *why* the module exists, not just what it contains. Design decisions and trade-offs belong here.
+- **Item-level `///` docs** must explain invariants, preconditions, panics, and non-obvious behavior. Do not repeat the function signature in prose.
+- **Challenge assumptions externally:** Before documenting a design choice, verify it against published research or first-class OSS references. Never document a claim that hasn't been validated.

--- a/crates/tdb-core/src/lib.rs
+++ b/crates/tdb-core/src/lib.rs
@@ -1,3 +1,87 @@
+//! Shared types, error definitions, and the fundamental storage unit of TardigradeDB.
+//!
+//! `tdb-core` is the vocabulary crate — it defines the language every other crate
+//! speaks. No business logic lives here. If you are adding a new field to a stored
+//! tensor or a new error variant, this is where you start.
+//!
+//! # What is a [`MemoryCell`]?
+//!
+//! TardigradeDB does not store text or embeddings. It stores **KV-cache tensors** —
+//! the exact `(key, value)` vectors a transformer produces at a specific layer during
+//! inference. A [`MemoryCell`] is the on-disk representation of one such tensor pair,
+//! along with enough metadata for the engine to manage its lifecycle autonomously.
+//!
+//! ```text
+//! Transformer attention head (layer L)
+//!   ┌──────────────────────────────────┐
+//!   │  Q · K^T / √d_k → softmax → · V │
+//!   │      ↑              ↑            │
+//!   │    key[L]        value[L]        │
+//!   └──────┬──────────────┬────────────┘
+//!          │              │    captured as f32 vectors
+//!          └──────┬───────┘
+//!                 ▼
+//!           MemoryCell { id, owner, layer, key, value, pos_encoding, meta }
+//! ```
+//!
+//! Key vectors are used for **retrieval** (attention scoring against a query).
+//! Value vectors are used for **injection** (inserted directly into the attention
+//! stack at read time, bypassing tokenization entirely).
+//!
+//! # Maturity Lifecycle — [`Tier`]
+//!
+//! Every cell is assigned a maturity tier that governs its storage priority and
+//! eviction eligibility:
+//!
+//! ```text
+//! Draft ──(ι ≥ 65)──► Validated ──(ι ≥ 85)──► Core
+//!       ◄──(ι < 35)──            ◄──(ι < 60)──
+//! ```
+//!
+//! Hysteresis gaps (30 points for Draft↔Validated, 25 for Validated↔Core) prevent
+//! oscillation when scores hover near a boundary. See `tdb-governance` for the
+//! importance score (ι) algorithm.
+//!
+//! # Error Handling
+//!
+//! All fallible operations across the workspace return [`error::Result<T>`], which
+//! wraps [`TardigradeError`]. Errors are defined here so that `tdb-storage`,
+//! `tdb-retrieval`, and other crates can return the same type without circular deps.
+//!
+//! # Crate Map
+//!
+//! | Crate | Role |
+//! |---|---|
+//! | **tdb-core** (this) | Shared types — `MemoryCell`, `Tier`, `TardigradeError` |
+//! | `tdb-storage` | Persist cells to append-only segments (Q4 quantized) |
+//! | `tdb-retrieval` | Retrieve cells by latent-space attention scoring |
+//! | `tdb-index` | Vamana ANN graph + causal Trace graph + WAL |
+//! | `tdb-governance` | Importance scoring, tier transitions, recency decay |
+//! | `tdb-engine` | Top-level facade orchestrating all layers |
+//!
+//! # Quick Example
+//!
+//! ```rust
+//! use tdb_core::memory_cell::MemoryCellBuilder;
+//! use tdb_core::types::Tier;
+//!
+//! // Capture a KV pair from layer 12 of a 4096-dim model.
+//! let cell = MemoryCellBuilder::new(
+//!     /* id */ 1,
+//!     /* owner */ 42,
+//!     /* layer */ 12,
+//!     /* key */ vec![0.1f32; 128],
+//!     /* value */ vec![0.2f32; 128],
+//! )
+//! .token_span(0, 64)
+//! .importance(50.0)
+//! .tier(Tier::Draft)
+//! .build();
+//!
+//! assert_eq!(cell.layer, 12);
+//! assert_eq!(cell.meta.tier, Tier::Draft);
+//! ```
+
 #![deny(unsafe_code)]
 
 pub mod error;

--- a/crates/tdb-engine/src/lib.rs
+++ b/crates/tdb-engine/src/lib.rs
@@ -1,3 +1,89 @@
+//! Top-level engine — the unified entry point for TardigradeDB.
+//!
+//! `tdb-engine` exposes a single [`Engine`] struct that coordinates the four
+//! architectural layers behind two operations: `MEM.WRITE` and `MEM.READ`.
+//! Everything else — quantization, indexing, importance scoring, tier transitions —
+//! happens automatically as a side effect of those two calls.
+//!
+//! # System Overview
+//!
+//! ```text
+//!                       ┌──────────────────────────┐
+//!    inference pass ──► │   Engine (Facade)        │ ◄── query key
+//!                       │                          │
+//!                       │  mem_write(owner, layer, │
+//!                       │    key, value, salience) │
+//!                       │  mem_read(query, k,      │
+//!                       │    owner_filter)         │
+//!                       └──────────┬───────────────┘
+//!                                  │ coordinates
+//!                    ┌─────────────┼──────────────────┐
+//!                    ▼             ▼                  ▼
+//!              BlockPool    BruteForceRetriever   ImportanceScorer
+//!              (tdb-storage) (tdb-retrieval)    + TierStateMachine
+//!                                               (tdb-governance)
+//! ```
+//!
+//! # Write Path — `mem_write`
+//!
+//! ```text
+//! mem_write(owner, layer, key, value, salience)
+//!   1. Assign a monotone CellId
+//!   2. Build a MemoryCell with current timestamp
+//!   3. BlockPool::append  → Q4-compress and fsync to segment file
+//!   4. BruteForceRetriever::insert  → index key for latent-space queries
+//!   5. ImportanceScorer::new(salience) + on_update (+5)
+//!   6. TierStateMachine::evaluate  → may immediately promote to Validated/Core
+//! ```
+//!
+//! # Read Path — `mem_read`
+//!
+//! ```text
+//! mem_read(query_key, k, owner_filter)
+//!   1. BruteForceRetriever::query(k*2)  → raw attention scores
+//!   2. recency_decay(days_since_update)  → down-weight stale cells
+//!   3. adjusted_score = raw_score × recency_factor
+//!   4. BlockPool::get  → dequantize cell from disk
+//!   5. ImportanceScorer::on_access (+3)  → boost accessed cells
+//!   6. TierStateMachine::evaluate  → potential promotion
+//!   7. Return top-k by adjusted score
+//! ```
+//!
+//! # Current Limitations (Phase 1)
+//!
+//! The engine is **partially ephemeral**: cells are durable on disk (via `BlockPool`),
+//! but the retrieval index and governance state are rebuilt in-memory from scratch
+//! on each `Engine::open`. A recovery pass that scans the `BlockPool` and rehydrates
+//! the `BruteForceRetriever` and `HashMap<CellId, CellGovernance>` is planned for
+//! Phase 2 (see the `TODO` in [`engine::Engine::open`]).
+//!
+//! # Usage
+//!
+//! ```rust,no_run
+//! use tdb_engine::engine::Engine;
+//!
+//! let dir = std::path::Path::new("/tmp/tardigrade");
+//! let mut engine = Engine::open(dir).unwrap();
+//!
+//! // Capture a KV pair from layer 12.
+//! let cell_id = engine.mem_write(
+//!     /* owner */ 42,
+//!     /* layer */ 12,
+//!     /* key */ &[0.1f32; 128],
+//!     /* value */ vec![0.2f32; 128],
+//!     /* salience */ 60.0,
+//! ).unwrap();
+//!
+//! // Retrieve the most relevant cell for a query key.
+//! let results = engine.mem_read(&[0.1f32; 128], /* k */ 5, None).unwrap();
+//! if let Some(top) = results.first() {
+//!     println!("top cell: id={} score={:.3} tier={:?}", top.cell.id, top.score, top.tier);
+//! }
+//! ```
+//!
+//! [`Engine`]: engine::Engine
+//! [`engine::Engine::open`]: engine::Engine::open
+
 #![deny(unsafe_code)]
 
 pub mod batch_cache;

--- a/crates/tdb-governance/src/lib.rs
+++ b/crates/tdb-governance/src/lib.rs
@@ -1,3 +1,94 @@
+//! Adaptive Knowledge Lifecycle (AKL) — autonomous memory management for TardigradeDB.
+//!
+//! `tdb-governance` implements the self-curating layer of the Aeon architecture.
+//! It answers the question: *given unlimited memory cells accumulating over time,
+//! which ones should be kept, promoted, demoted, or evicted — and when?*
+//!
+//! No application code manages cell lifecycle. The AKL does it automatically based
+//! on observed access patterns and elapsed time.
+//!
+//! # Importance Score (ι)
+//!
+//! Every cell carries an importance score ι ∈ \[0.0, 100.0\] managed by [`ImportanceScorer`].
+//!
+//! ```text
+//! Event        │ Effect on ι
+//! ─────────────┼──────────────────────────────────
+//! Read access  │ +3.0  (capped at 100.0)
+//! Write/update │ +5.0  (capped at 100.0)
+//! Each day     │ × 0.995  (≈ 0.5% decay per day)
+//! ```
+//!
+//! The daily decay factor of 0.995 produces a **half-life of approximately 138 days**
+//! for a cell that is never accessed (ln(0.5) / ln(0.995) ≈ 138). A cell accessed
+//! daily stabilizes around ι ≈ 60 (3 / (1 - 0.995)).
+//!
+//! # Tier State Machine
+//!
+//! [`TierStateMachine`] maps ι to one of three maturity tiers, using **hysteresis
+//! gaps** to prevent oscillation when scores hover near a boundary:
+//!
+//! ```text
+//! ┌─────────────────────────────────────────────────────────────────┐
+//! │                                                                 │
+//! │  DRAFT ──────(ι ≥ 65)──────► VALIDATED ──────(ι ≥ 85)──────► CORE
+//! │         ◄────(ι < 35)────                ◄────(ι < 60)────      │
+//! │                                                                 │
+//! │  Hysteresis gaps:  Draft↔Validated = 30 pts                    │
+//! │                    Validated↔Core  = 25 pts                    │
+//! └─────────────────────────────────────────────────────────────────┘
+//! ```
+//!
+//! Skipping tiers is supported: a new cell with ι = 90 will transition
+//! `Draft → Validated → Core` in a single [`TierStateMachine::evaluate`] call.
+//!
+//! # Recency Decay
+//!
+//! [`recency_decay`] computes an exponential multiplier applied during retrieval
+//! to down-weight cells that haven't been touched recently:
+//!
+//! ```text
+//! r = exp(-Δt / τ),  τ = 30 days  (half-life ≈ 20.8 days)
+//!
+//! Δt = 0 days  →  r = 1.00  (fresh)
+//! Δt ≈ 21 days →  r ≈ 0.50  (half-weight)
+//! Δt = 30 days →  r ≈ 0.37  (one time-constant)
+//! Δt = 90 days →  r ≈ 0.05  (near-zero)
+//! ```
+//!
+//! This is applied as a **score multiplier** at query time, not as a modification
+//! to the stored ι. It means a stale cell with a high importance score will still
+//! rank lower than a recently-accessed cell with a moderate score.
+//!
+//! # Usage
+//!
+//! ```rust
+//! use tdb_governance::scoring::ImportanceScorer;
+//! use tdb_governance::tiers::TierStateMachine;
+//! use tdb_governance::decay::recency_decay;
+//! use tdb_core::Tier;
+//!
+//! let mut scorer = ImportanceScorer::new(50.0);
+//! scorer.on_access();   // +3 → 53.0
+//! scorer.on_update();   // +5 → 58.0
+//! scorer.apply_daily_decay(30); // ×0.995^30 ≈ ×0.861 → ~49.9
+//!
+//! let mut tier = TierStateMachine::new(); // starts at Draft
+//! tier.evaluate(scorer.importance());    // still Draft (< 65)
+//!
+//! // Recency factor for a cell last updated 21 days ago.
+//! let r = recency_decay(21.0);
+//! assert!(r > 0.49 && r < 0.51); // ≈ half-life
+//!
+//! // Final adjusted retrieval score:
+//! let adjusted = scorer.importance() * r;
+//! ```
+//!
+//! [`ImportanceScorer`]: scoring::ImportanceScorer
+//! [`TierStateMachine`]: tiers::TierStateMachine
+//! [`TierStateMachine::evaluate`]: tiers::TierStateMachine::evaluate
+//! [`recency_decay`]: decay::recency_decay
+
 #![deny(unsafe_code)]
 
 pub mod decay;

--- a/crates/tdb-index/src/lib.rs
+++ b/crates/tdb-index/src/lib.rs
@@ -1,3 +1,106 @@
+//! Organization layer for TardigradeDB: ANN graph, causal graph, and write-ahead log.
+//!
+//! `tdb-index` implements the **neuro-symbolic dual topology** described in the Aeon
+//! architecture: two complementary data structures that organize memory cells, plus a
+//! WAL for crash recovery of the causal graph.
+//!
+//! # Vamana Graph — Vector Index
+//!
+//! [`VamanaIndex`] is a **DiskANN-style single-layer graph** for approximate nearest
+//! neighbor (ANN) search. It is the cold-path index used when the per-agent cell count
+//! grows beyond the brute-force threshold (~10K) handled by `tdb-retrieval`.
+//!
+//! ```text
+//! Insert phase:                         Query phase:
+//! ┌───────┐  insert(id, vec)            query(q, k=5)
+//! │       │ ──────────────────►         │
+//! │ nodes │   add node to list          ▼ greedy beam search
+//! │       │                        seed at medoid
+//! └───────┘  build()               expand best candidates
+//!             │                    explore neighbor edges
+//!             ▼                    return top-k by score
+//!    connect each node to
+//!    its R nearest neighbors
+//! ```
+//!
+//! **Key design choices vs. HNSW:**
+//! - Single layer (no multi-layer hierarchy) → simpler build, faster cold-start
+//! - Medoid seeding → avoids pathological cases when queries are far from the centroid
+//! - Page-clustered insertions (future) → DiskANN's disk-locality trick for NVMe I/O
+//!
+//! Configuration:
+//! - `max_degree` (R): out-degree per node. Higher = better recall, more memory.
+//! - `search_list_size` (L) is set automatically to `max(k, R) * 2` during queries.
+//!
+//! # Trace Graph — Causal Index
+//!
+//! [`TraceGraph`] is a **directed episodic graph** where nodes are [`CellId`]s and
+//! edges represent causal relationships between stored memories:
+//!
+//! ```text
+//!   cell_A ──[CausedBy]──► cell_B ──[CausedBy]──► cell_C
+//!   cell_A ──[Supports]──► cell_D
+//!   cell_E ──[Contradicts]► cell_A
+//! ```
+//!
+//! Edge types: `CausedBy`, `Follows`, `Supports`, `Contradicts`.
+//!
+//! The graph supports transitive ancestor queries (`ancestors(node, EdgeType)`),
+//! which an agent can use to reconstruct the causal chain that led to any stored memory.
+//!
+//! # Write-Ahead Log — Crash Recovery
+//!
+//! [`Wal`] is an append-only binary log that records every [`TraceGraph`] mutation
+//! before it is applied. On restart, mutations are replayed from the WAL before the
+//! in-memory graph is used.
+//!
+//! ```text
+//! Graph mutation requested
+//!        │
+//!        ▼
+//!   WAL.append(entry)   ← fsync to disk FIRST
+//!        │
+//!        ▼
+//!   TraceGraph.add_edge(...)   ← then apply in memory
+//!        │
+//!        ▼
+//!   (periodic) WAL.checkpoint()  ← truncate WAL after snapshot
+//! ```
+//!
+//! WAL record format (little-endian): `type(1) | src(8) | dst(8) | edge_type(1) | timestamp(8)`
+//! = 26 bytes per record. Fixed-size records allow O(1) position arithmetic during replay.
+//!
+//! # Usage
+//!
+//! ```rust,no_run
+//! use tdb_index::vamana::VamanaIndex;
+//! use tdb_index::trace::{TraceGraph, EdgeType};
+//! use tdb_index::wal::Wal;
+//!
+//! // Build a vector index for cold-path ANN retrieval.
+//! let mut idx = VamanaIndex::new(/* dim */ 128, /* max_degree */ 32);
+//! idx.insert(0, &[0.5f32; 128]);
+//! idx.insert(1, &[0.1f32; 128]);
+//! idx.build(); // O(n²) — call after all inserts
+//! let results = idx.query(&[0.5f32; 128], /* k */ 1);
+//! assert_eq!(results[0].0, 0);
+//!
+//! // Record a causal edge between two cells (WAL-backed).
+//! let dir = std::path::Path::new("/tmp/tdb-wal");
+//! let mut wal = Wal::open(dir).unwrap();
+//! let mut graph = TraceGraph::new();
+//! let entry = tdb_index::wal::WalEntry::AddEdge {
+//!     src: 0, dst: 1, edge_type: EdgeType::CausedBy as u8, timestamp: 1000,
+//! };
+//! wal.append(&entry).unwrap();        // durable FIRST
+//! graph.add_edge(0, 1, EdgeType::CausedBy, 1000); // then in memory
+//! ```
+//!
+//! [`VamanaIndex`]: vamana::VamanaIndex
+//! [`TraceGraph`]: trace::TraceGraph
+//! [`Wal`]: wal::Wal
+//! [`CellId`]: tdb_core::CellId
+
 #![deny(unsafe_code)]
 
 pub mod trace;

--- a/crates/tdb-retrieval/src/lib.rs
+++ b/crates/tdb-retrieval/src/lib.rs
@@ -1,3 +1,77 @@
+//! Latent-space retrieval for TardigradeDB — find relevant memory cells by attention scoring.
+//!
+//! TardigradeDB does not use cosine similarity over text embeddings. Relevance is computed
+//! as **scaled dot-product attention** directly in the model's latent space:
+//!
+//! ```text
+//! score(q, k) = (q · k) / √d_k
+//! ```
+//!
+//! This is the same formula used inside a transformer's attention head. Querying memory
+//! with a key vector from a live inference pass means the retrieval metric is identical
+//! to how the model itself relates tokens — no separate embedding model required.
+//!
+//! # Two-Level Retrieval
+//!
+//! ```text
+//! query key vector
+//!       │
+//!       ▼
+//! ┌─────────────────────────────────────────┐
+//! │  SemanticLookasideBuffer (hot path)     │
+//! │  • Fixed-capacity LRU, INT8 keys        │
+//! │  • Target: < 5 μs via SIMD dot product  │
+//! │  • HIT → return immediately             │
+//! └─────────────┬───────────────────────────┘
+//!               │ MISS
+//!               ▼
+//! ┌─────────────────────────────────────────┐
+//! │  BruteForceRetriever (cold path)        │
+//! │  • Full f32 exhaustive scan             │
+//! │  • Owner-filtered per-agent partitions  │
+//! │  • Valid up to ~10K cells per agent     │
+//! └─────────────────────────────────────────┘
+//! ```
+//!
+//! ## Why Brute Force, Not ANN?
+//!
+//! The [MemArt paper] (which this architecture cites) demonstrates that at typical
+//! per-agent memory scales (<10K blocks), SIMD brute-force matmul outperforms HNSW
+//! and other approximate nearest-neighbor indexes. ANN indexes pay a build-time and
+//! index-memory overhead that only pays off beyond ~100K vectors. For larger cold
+//! indexes, `tdb-index` provides a Vamana graph (DiskANN-style).
+//!
+//! Additionally, HNSW is unreliable for Q/K distributions that shift over time
+//! (which happens as the model processes different contexts), because its graph
+//! edges are built against a snapshot distribution.
+//!
+//! ## Semantic Lookaside Buffer
+//!
+//! The [`SemanticLookasideBuffer`] is modeled on a CPU's Translation Lookaside Buffer:
+//! a fast fixed-size cache for the most recently used entries. It stores keys in
+//! **symmetric INT8 quantization** — one scale per full vector instead of per-group —
+//! which allows the dot product to be computed as integer arithmetic using NEON
+//! `SDOT` intrinsics (ARM) or equivalent auto-vectorized code on x86.
+//!
+//! # Usage
+//!
+//! ```rust
+//! use tdb_retrieval::attention::BruteForceRetriever;
+//!
+//! let mut retriever = BruteForceRetriever::new();
+//!
+//! // Index a set of key vectors (from stored cells).
+//! retriever.insert(/* cell_id */ 0, /* owner */ 1, /* layer */ 12, &[1.0, 0.0, 0.0, 0.0]);
+//! retriever.insert(/* cell_id */ 1, /* owner */ 1, /* layer */ 12, &[0.0, 1.0, 0.0, 0.0]);
+//!
+//! // Query with a key from the current inference pass.
+//! let results = retriever.query(&[1.0, 0.0, 0.0, 0.0], /* k */ 1, /* owner_filter */ None);
+//! assert_eq!(results[0].cell_id, 0); // exact-match cell scores highest
+//! ```
+//!
+//! [`SemanticLookasideBuffer`]: slb::SemanticLookasideBuffer
+//! [MemArt paper]: https://arxiv.org/abs/2409.17264
+
 pub mod attention;
 pub mod int8_quant;
 pub mod simd_distance;

--- a/crates/tdb-storage/src/lib.rs
+++ b/crates/tdb-storage/src/lib.rs
@@ -1,3 +1,97 @@
+//! Persistent quantized storage for KV-cache tensors — the storage layer of TardigradeDB.
+//!
+//! `tdb-storage` owns the write path: it receives [`MemoryCell`] values, compresses
+//! their key and value vectors to Q4 (4-bit), and appends them to an mmap-backed
+//! segment file. Reads dequantize on-the-fly. The entire layer is crash-safe via
+//! append-only writes and a monotone index rebuild on open.
+//!
+//! # Architecture
+//!
+//! ```text
+//! ┌─────────────────────────────────────────────────────┐
+//! │                     BlockPool                        │
+//! │                                                      │
+//! │  in-memory:  BTreeMap<CellId → (segment_id, offset)>│
+//! │                         │                            │
+//! │  on-disk:   ┌──────────┐ ┌──────────┐ ┌──────────┐  │
+//! │             │ seg_000  │ │ seg_001  │ │ seg_002  │  │  ← append-only files
+//! │             │  256 MB  │ │  256 MB  │ │ (active) │  │
+//! │             └──────────┘ └──────────┘ └──────────┘  │
+//! └─────────────────────────────────────────────────────┘
+//! ```
+//!
+//! Each segment file is a sequential log of binary records. New records are always
+//! appended; existing records are never mutated. On open, [`BlockPool`] scans all
+//! segments to rebuild the `CellId → location` index — this is the recovery path.
+//!
+//! # Quantization
+//!
+//! Key and value vectors are stored in **Q4 group-wise 4-bit** format, matching the
+//! `Q4_0` scheme from [llama.cpp]. Each group of 32 floats shares one `f32` scale
+//! factor; the 32 values are quantized to 4-bit unsigned integers and packed two-per-byte.
+//!
+//! Compression characteristics vs. raw `f32`:
+//! - **Size**: ~4× smaller (4 bits vs 32 bits per element, plus scale overhead)
+//! - **Error**: mean squared error < 0.01 on typical activation distributions
+//! - **Speed**: dequantize is a simple multiply-and-shift, negligible vs. I/O
+//!
+//! Position encodings are stored **unquantized** (`f32`) because they must be
+//! reproduced exactly for safe historical KV block reuse.
+//!
+//! # Segment File Format
+//!
+//! ```text
+//! ┌─────────────────────────┐
+//! │ magic: "TDBS" (4 bytes) │
+//! │ version: u32 (4 bytes)  │
+//! ├─────────────────────────┤  ← FILE_HEADER_SIZE = 8
+//! │ record_len: u32         │  ← total bytes of this record (excludes this field)
+//! │ cell_id: u64            │
+//! │ owner: u64              │
+//! │ layer: u16              │
+//! │ … fixed metadata …      │
+//! │ key (Q4 packed)         │
+//! │ value (Q4 packed)       │
+//! │ pos_encoding (f32[])    │
+//! ├─────────────────────────┤
+//! │ … next record …         │
+//! └─────────────────────────┘
+//! ```
+//!
+//! All integers are **little-endian**. The `record_len` prefix enables the recovery
+//! scanner to skip partial records at EOF without corrupting the index.
+//!
+//! # Recovery
+//!
+//! [`block_pool::BlockPool::open`] rebuilds the entire in-memory index by calling [`scan_segment`]
+//! on every segment file. `scan_segment` reads only the `record_len` and `cell_id`
+//! prefix of each record — it does not deserialize the full tensor — making recovery
+//! proportional to the number of cells, not their size. Partial records at EOF
+//! (from a crash mid-write) are silently discarded.
+//!
+//! # Usage
+//!
+//! ```rust,no_run
+//! use tdb_storage::block_pool::BlockPool;
+//! use tdb_core::memory_cell::MemoryCellBuilder;
+//!
+//! let dir = std::path::Path::new("/tmp/tdb-data");
+//! let mut pool = BlockPool::open(dir).unwrap();
+//!
+//! // Write a cell (key/value are compressed to Q4 on disk).
+//! let cell = MemoryCellBuilder::new(0, 1, 12, vec![0.5f32; 64], vec![0.3f32; 64]).build();
+//! let cell_id = pool.append(&cell).unwrap();
+//!
+//! // Read it back (dequantized from Q4).
+//! let retrieved = pool.get(cell_id).unwrap();
+//! assert_eq!(retrieved.id, 0);
+//! ```
+//!
+//! [`MemoryCell`]: tdb_core::memory_cell::MemoryCell
+//! [`BlockPool`]: block_pool::BlockPool
+//! [`scan_segment`]: segment::scan_segment
+//! [llama.cpp]: https://github.com/ggerganov/llama.cpp
+
 #![deny(unsafe_code)]
 
 pub mod arena;


### PR DESCRIPTION
## Summary

- Every `lib.rs` was previously blank when viewed in `cargo doc` — zero crate-level `//!` docs existed
- Added full crate-level documentation to all six crates (`tdb-core`, `tdb-storage`, `tdb-retrieval`, `tdb-index`, `tdb-governance`, `tdb-engine`) following the standard set by tokio, serde, and crossbeam
- Added a **Documentation Standards** section to `CLAUDE.md` to codify this quality bar for future contributions

## What each crate doc includes

| Crate | Highlights |
|---|---|
| `tdb-core` | MemoryCell/transformer connection diagram, Tier hysteresis diagram, crate map table |
| `tdb-storage` | BlockPool segment layout diagram, Q4 compression stats, binary record format, recovery behavior |
| `tdb-retrieval` | Two-level hot/cold retrieval flow diagram, why-brute-force-not-ANN rationale (MemArt paper) |
| `tdb-index` | Vamana insert vs query flow, Trace causal graph example, WAL write-before-apply sequence |
| `tdb-governance` | ι score event table, tier state machine diagram with hysteresis gaps, recency decay curve |
| `tdb-engine` | System overview diagram, write path and read path step-by-step, current Phase 1 limitations |

## Test plan

- [ ] `cargo doc --workspace --no-deps --exclude tdb-python` builds with zero warnings
- [ ] Visit `target/doc/tdb_core/index.html` and confirm each crate has a populated landing page
- [ ] Confirm all intra-doc links resolve (no broken link warnings in doc output)